### PR TITLE
Updated Runloop for scrolling purposes

### DIFF
--- a/Skycons-Swift/SKYIconView.swift
+++ b/Skycons-Swift/SKYIconView.swift
@@ -125,6 +125,7 @@ class SKYIconView: UIView {
             self.pause()
         }
         self._timer = Timer.scheduledTimer(timeInterval: 1/30, target: self, selector: #selector(update(_:)), userInfo: nil, repeats: true)
+        RunLoop.main.add(_timer, forMode: .commonModes)
     }
     
     func pause() {


### PR DESCRIPTION
When using these icons in conjunction with any UIKit elements subclassing UIScrollView, the animations sticks. Adding runloop ensures the timer isn't blocked. 
Before:
![2019-08-28 17-37-46 2019-08-28 17_38_24](https://user-images.githubusercontent.com/18126362/63894544-e08dcc00-c9ba-11e9-855a-788838dfcc25.gif)

After:
![2019-08-28 17-39-05 2019-08-28 17_39_34](https://user-images.githubusercontent.com/18126362/63894549-e388bc80-c9ba-11e9-895d-bf8f474f8259.gif)

